### PR TITLE
[renec] Fix verichains audit

### DIFF
--- a/programs/whirlpool/src/instructions/initialize_pool.rs
+++ b/programs/whirlpool/src/instructions/initialize_pool.rs
@@ -1,15 +1,13 @@
-use crate::{state::*, errors::ErrorCode};
+use crate::state::*;
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Mint, Token, TokenAccount};
-use spl_token::native_mint;
 
 #[derive(Accounts)]
 #[instruction(bumps: WhirlpoolBumps, tick_spacing: u16)]
 pub struct InitializePool<'info> {
     pub whirlpools_config: Box<Account<'info, WhirlpoolsConfig>>,
 
-    /// CHECK: token_mint_a will be verified in handler, 
-    pub token_mint_a: UncheckedAccount<'info>,
+    pub token_mint_a: Account<'info, Mint>,
     pub token_mint_b: Account<'info, Mint>,
 
     #[account(mut)]
@@ -57,20 +55,6 @@ pub fn handler(
 ) -> ProgramResult {
     let token_mint_a = ctx.accounts.token_mint_a.key();
     let token_mint_b = ctx.accounts.token_mint_b.key();
-
-    if token_mint_a.eq(&token_mint_b) {
-      return Err(ErrorCode::InvalidTokenMintOrder.into());
-    }
-    
-    // Only check Mint Info when token a is not a native mint.
-    if !native_mint::check_id(&token_mint_a) {
-      let mut data: &[u8] = &ctx.accounts.token_mint_a.try_borrow_data()?;
-      Mint::try_deserialize(&mut data)?;
-
-      if token_mint_a.ge(&token_mint_b) {
-        return Err(ErrorCode::InvalidTokenMintOrder.into());
-      }
-    }
 
     let whirlpool = &mut ctx.accounts.whirlpool;
     let whirlpools_config = &ctx.accounts.whirlpools_config;

--- a/programs/whirlpool/src/lib.rs
+++ b/programs/whirlpool/src/lib.rs
@@ -1,7 +1,7 @@
 //! A concentrated liquidity AMM contract powered by Orca.
 use anchor_lang::prelude::*;
 
-declare_id!("__PROGRAM_ID__");
+declare_id!("7yyFRQehBQjdSpWYV93jWh4558YbWmc4ofbMWzKTPyJL");
 
 #[doc(hidden)]
 pub mod constants;
@@ -502,10 +502,7 @@ pub mod whirlpool {
 
     /// Sets `enable` flag of the pool to enable or disable this pool.
     /// Only the current pool creator authority has permission to invoke this instruction.
-    pub fn set_enable_flag(
-        ctx: Context<SetEnableFlag>,
-        is_enabled: bool,
-    ) -> ProgramResult {
+    pub fn set_enable_flag(ctx: Context<SetEnableFlag>, is_enabled: bool) -> ProgramResult {
         return instructions::set_enable_flag::handler(ctx, is_enabled);
     }
 }

--- a/programs/whirlpool/src/lib.rs
+++ b/programs/whirlpool/src/lib.rs
@@ -466,7 +466,7 @@ pub mod whirlpool {
     /// Only the current pool creator authority has permission to invoke this instruction.
     ///
     /// ### Authority
-    /// - "pool_creator_authority" - Set authority that can create a new pool in the WhirlpoolConfig
+    /// - "pool_creator_authority" - Set authority that can disable a pool in the WhirlpoolConfig
     pub fn set_pool_creator_authority(ctx: Context<SetPoolCreatorAuthority>) -> ProgramResult {
         return instructions::set_pool_creator_authority::handler(ctx);
     }

--- a/programs/whirlpool/src/lib.rs
+++ b/programs/whirlpool/src/lib.rs
@@ -1,7 +1,7 @@
 //! A concentrated liquidity AMM contract powered by Orca.
 use anchor_lang::prelude::*;
 
-declare_id!("7yyFRQehBQjdSpWYV93jWh4558YbWmc4ofbMWzKTPyJL");
+declare_id!("__PROGRAM_ID__");
 
 #[doc(hidden)]
 pub mod constants;

--- a/programs/whirlpool/src/state/config.rs
+++ b/programs/whirlpool/src/state/config.rs
@@ -13,7 +13,7 @@ pub struct WhirlpoolsConfig {
 }
 
 impl WhirlpoolsConfig {
-    pub const LEN: usize = 8 + 128 + 4;
+    pub const LEN: usize = 8 + 128 + 2;
 
     pub fn update_fee_authority(&mut self, fee_authority: Pubkey) {
         self.fee_authority = fee_authority;

--- a/programs/whirlpool/src/state/whirlpool.rs
+++ b/programs/whirlpool/src/state/whirlpool.rs
@@ -12,7 +12,7 @@ use super::WhirlpoolsConfig;
 #[account]
 #[derive(Default)]
 pub struct Whirlpool {
-    // if the `is_enabled` is false,  
+    // if the `is_enabled` is false,
     // the swap, open/close position and deposit/withdraw liquidity would be disabled.
     pub is_enabled: bool, // 1
 
@@ -85,6 +85,10 @@ impl Whirlpool {
         token_mint_b: Pubkey,
         token_vault_b: Pubkey,
     ) -> Result<(), ErrorCode> {
+        if token_mint_a.eq(&token_mint_b) {
+            return Err(ErrorCode::InvalidTokenMintOrder.into());
+        }
+
         if sqrt_price < MIN_SQRT_PRICE_X64 || sqrt_price > MAX_SQRT_PRICE_X64 {
             return Err(ErrorCode::SqrtPriceOutOfBounds.into());
         }

--- a/programs/whirlpool/src/state/whirlpool.rs
+++ b/programs/whirlpool/src/state/whirlpool.rs
@@ -85,7 +85,7 @@ impl Whirlpool {
         token_mint_b: Pubkey,
         token_vault_b: Pubkey,
     ) -> Result<(), ErrorCode> {
-        if token_mint_a.eq(&token_mint_b) {
+        if token_mint_a.ge(&token_mint_b) {
             return Err(ErrorCode::InvalidTokenMintOrder.into());
         }
 


### PR DESCRIPTION
## Vivify ticket
  *`[BDFR-258](https://app.vivifyscrum.com/boards/114704/sprint-backlog/373800/BDFR-258)`*

## Note
 Verichains audit 
  - fix cnsafe UncheckedAccount for token_mint_a
  - fix can initialize 2 pools for a pair with native mint
  - doc: update doc for pool_creator_authority
  - perf: update correct space allocation for whirlpool config 


## Checklist
  <pre lang="checklist">
  https://checklist.remop.info/remitano-remitano/pr-nemoswap-8
  </pre>

