### PR TITLE
[need-fix][renec] Fix/sorted token before getting pool

### DIFF
--- a/scripts/create_pool/02_init_pool.ts
+++ b/scripts/create_pool/02_init_pool.ts
@@ -37,7 +37,7 @@ async function main() {
       console.log("===================================================");
       console.log("token_a:", mintAPub.toBase58());
       console.log("token_b:", mintBPub.toBase58());
-      console.log("tick_spacing:", poolInfo.tokenMintB);
+      console.log("tick_spacing:", poolInfo.tickSpacing);
 
       const whirlpoolPda = PDAUtil.getWhirlpool(
         ctx.program.programId,

--- a/scripts/create_pool/02_init_pool.ts
+++ b/scripts/create_pool/02_init_pool.ts
@@ -4,6 +4,7 @@ import { loadProvider, getTokenMintInfo, loadWallets } from "./utils";
 import Decimal from "decimal.js";
 import config from "./config.json";
 import deployed from "./deployed.json";
+import { askToConfirmPoolInfo, getPoolInfo } from "./utils/pool";
 
 async function main() {
   const wallets = loadWallets();
@@ -24,9 +25,11 @@ async function main() {
   const client = buildWhirlpoolClient(ctx);
 
   for (let i = 0; i < config.POOLS.length; i++) {
-    const pool = config.POOLS[i];
-    const mintAPub = new PublicKey(pool.TOKEN_MINT_A);
-    const mintBPub = new PublicKey(pool.TOKEN_MINT_B);
+    let poolInfo = getPoolInfo(i);
+    await askToConfirmPoolInfo(poolInfo);
+
+    const mintAPub = new PublicKey(poolInfo.tokenMintA);
+    const mintBPub = new PublicKey(poolInfo.tokenMintB);
     const tokenMintA = await getTokenMintInfo(ctx, mintAPub);
     const tokenMintB = await getTokenMintInfo(ctx, mintBPub);
 
@@ -34,14 +37,14 @@ async function main() {
       console.log("===================================================");
       console.log("token_a:", mintAPub.toBase58());
       console.log("token_b:", mintBPub.toBase58());
-      console.log("tick_spacing:", pool.TICK_SPACING);
+      console.log("tick_spacing:", poolInfo.tokenMintB);
 
       const whirlpoolPda = PDAUtil.getWhirlpool(
         ctx.program.programId,
         REDEX_CONFIG_PUB,
         mintAPub,
         mintBPub,
-        pool.TICK_SPACING
+        poolInfo.tickSpacing
       );
 
       try {
@@ -61,18 +64,18 @@ async function main() {
       }
       console.log("deploying new pool...");
 
-      const currentA2BPrice = new Decimal(pool.INIT_AMOUNT_B_PER_A);
+      const currentA2BPrice = new Decimal(poolInfo.initialAmountBPerA);
       const tickIndex = PriceMath.priceToInitializableTickIndex(
         currentA2BPrice,
         tokenMintA.decimals,
         tokenMintB.decimals,
-        pool.TICK_SPACING
+        poolInfo.tickSpacing
       );
       const { poolKey, tx } = await client.createPool(
         REDEX_CONFIG_PUB,
-        pool.TOKEN_MINT_A,
-        pool.TOKEN_MINT_B,
-        pool.TICK_SPACING,
+        poolInfo.tokenMintA,
+        poolInfo.tokenMintB,
+        poolInfo.tickSpacing,
         tickIndex,
         ctx.wallet.publicKey
       );

--- a/scripts/create_pool/03_open_position.ts
+++ b/scripts/create_pool/03_open_position.ts
@@ -11,6 +11,7 @@ import Decimal from "decimal.js";
 import config from "./config.json";
 import deployed from "./deployed.json";
 import { askToConfirmPoolInfo, getPoolInfo } from "./utils/pool";
+import { u64 } from "@solana/spl-token";
 
 async function main() {
   const wallets = loadWallets();
@@ -49,44 +50,57 @@ async function main() {
       );
       const whirlpool = await client.getPool(whirlpoolPda.publicKey);
 
-      if (whirlpool && pool.OPEN_POSITION) {
+      if (whirlpool && poolInfo.isOpenPosition) {
         console.log("===================================================");
         const whirlpoolData = whirlpool.getData();
-        const lowerPrice = new Decimal(pool.LOWER_B_PER_A_PRICE);
-        const upperPrice = new Decimal(pool.UPPER_B_PER_A_PRICE);
+        const lowerPrice = new Decimal(poolInfo.lowerBPerAPrice);
+        const upperPrice = new Decimal(poolInfo.upperBPerAPrice);
         const slippageTolerance = Percentage.fromDecimal(
-          new Decimal(pool.SLIPPAGE)
+          new Decimal(poolInfo.slippage)
         );
 
         console.log("lower_b_per_a:", lowerPrice.toFixed(6));
         console.log("upper_b_per_a:", upperPrice.toFixed(6));
         console.log("slippage:", slippageTolerance.toString());
-        console.log("input_mint:", pool.INPUT_MINT);
-        console.log("input_amount:", pool.INPUT_AMOUNT);
+        console.log("input_mint:", poolInfo.inputMint);
+        console.log("input_amount:", poolInfo.inputAmount);
 
         const tickLowerIndex = PriceMath.priceToInitializableTickIndex(
           lowerPrice,
           tokenMintA.decimals,
           tokenMintB.decimals,
-          pool.TICK_SPACING
+          poolInfo.tickSpacing
         );
         const tickUpperIndex = PriceMath.priceToInitializableTickIndex(
           upperPrice,
           tokenMintA.decimals,
           tokenMintB.decimals,
-          pool.TICK_SPACING
+          poolInfo.tickSpacing
         );
 
-        const inputTokenMint = new PublicKey(pool.INPUT_MINT);
-        const inputTokenAmount = DecimalUtil.toU64(
-          new Decimal(pool.INPUT_AMOUNT),
-          tokenMintA.decimals
-        );
+        const inputTokenMint = new PublicKey(poolInfo.inputMint);
+
+        // Get correct input token amount
+        let inputTokenAmount: u64;
+        if (poolInfo.inputMint === mintAPub.toString()) {
+          inputTokenAmount = DecimalUtil.toU64(
+            new Decimal(poolInfo.inputAmount),
+            tokenMintA.decimals
+          );
+        } else if (poolInfo.inputMint === mintBPub.toString()) {
+          inputTokenAmount = DecimalUtil.toU64(
+            new Decimal(poolInfo.inputAmount),
+            tokenMintB.decimals
+          );
+        } else {
+          throw new Error("Input token is not matched");
+        }
 
         const initTickTx = await whirlpool.initTickArrayForTicks([
           tickLowerIndex,
           tickUpperIndex,
         ]);
+
         const quote = increaseLiquidityQuoteByInputTokenWithParams({
           tokenMintA: mintAPub,
           tokenMintB: mintBPub,

--- a/scripts/create_pool/03_open_position.ts
+++ b/scripts/create_pool/03_open_position.ts
@@ -10,6 +10,7 @@ import { loadProvider, getTokenMintInfo, loadWallets } from "./utils";
 import Decimal from "decimal.js";
 import config from "./config.json";
 import deployed from "./deployed.json";
+import { askToConfirmPoolInfo, getPoolInfo } from "./utils/pool";
 
 async function main() {
   const wallets = loadWallets();
@@ -31,9 +32,10 @@ async function main() {
   const client = buildWhirlpoolClient(ctx);
 
   for (let i = 0; i < config.POOLS.length; i++) {
-    const pool = config.POOLS[i];
-    const mintAPub = new PublicKey(pool.TOKEN_MINT_A);
-    const mintBPub = new PublicKey(pool.TOKEN_MINT_B);
+    let poolInfo = getPoolInfo(i);
+    await askToConfirmPoolInfo(poolInfo);
+    const mintAPub = new PublicKey(poolInfo.tokenMintA);
+    const mintBPub = new PublicKey(poolInfo.tokenMintB);
     const tokenMintA = await getTokenMintInfo(ctx, mintAPub);
     const tokenMintB = await getTokenMintInfo(ctx, mintBPub);
 
@@ -43,7 +45,7 @@ async function main() {
         REDEX_CONFIG_PUB,
         mintAPub,
         mintBPub,
-        pool.TICK_SPACING
+        poolInfo.tickSpacing
       );
       const whirlpool = await client.getPool(whirlpoolPda.publicKey);
 

--- a/scripts/create_pool/05_close_position.ts
+++ b/scripts/create_pool/05_close_position.ts
@@ -5,6 +5,7 @@ import { loadProvider, getTokenMintInfo, loadWallets } from "./utils";
 import Decimal from "decimal.js";
 import config from "./config.json";
 import deployed from "./deployed.json";
+import { askToConfirmPoolInfo, getPoolInfo } from "./utils/pool";
 
 async function main() {
   const wallets = loadWallets();
@@ -26,9 +27,13 @@ async function main() {
   const positions = await client.getAllPositionsOf(ctx.wallet.publicKey);
 
   for (let i = 0; i < config.POOLS.length; i++) {
+    let poolInfo = getPoolInfo(i);
+    await askToConfirmPoolInfo(poolInfo);
+
     const pool = config.POOLS[i];
-    const mintAPub = new PublicKey(pool.TOKEN_MINT_A);
-    const mintBPub = new PublicKey(pool.TOKEN_MINT_B);
+    const mintAPub = new PublicKey(poolInfo.tokenMintA);
+    const mintBPub = new PublicKey(poolInfo.tokenMintB);
+
     const tokenMintA = await getTokenMintInfo(ctx, mintAPub);
     const tokenMintB = await getTokenMintInfo(ctx, mintBPub);
 

--- a/scripts/create_pool/config.json
+++ b/scripts/create_pool/config.json
@@ -1,6 +1,6 @@
 {
-    "RPC_ENDPOINT_URL": "https://api-testnet.renec.foundation:8899/",
-    "REDEX_PROGRAM_ID": "8wFUkeo6humf9BxnjEZEqU32voXQ3fwVKeRF6dMcebyW",
+    "RPC_ENDPOINT_URL": "https://api-mainnet-beta.renec.foundation:8899",
+    "REDEX_PROGRAM_ID": "__PROGRAM_ID__",
     "PROTOCOL_FEE_RATE": 300,
     "FEE_TIERS": [
         {
@@ -10,15 +10,15 @@
     ],
     "POOLS": [
         {
-            "TOKEN_MINT_A": "4yKRzD9MCGC39hb11kSfgnaA9sbKbBec42jDRAqdaLnP",
-            "TOKEN_MINT_B": "3JVvARFtkKwF6X8HQvt2GTTGsmaranqMk7YCn5RX7HG5",
-            "TICK_SPACING": 30,
+            "TOKEN_MINT_A": "So11111111111111111111111111111111111111112",
+            "TOKEN_MINT_B": "4Q89182juiadeFgGw3fupnrwnnDmBhf7e7fHWxnUP3S3",
+            "TICK_SPACING": 32,
             "OPEN_POSITION": true,
-            "INIT_AMOUNT_B_PER_A": "3.0",
+            "INIT_AMOUNT_B_PER_A": "1.0",
             "LOWER_B_PER_A_PRICE": "0.0001",
             "UPPER_B_PER_A_PRICE": "100",
             "SLIPPAGE": "1",
-            "INPUT_MINT": "4yKRzD9MCGC39hb11kSfgnaA9sbKbBec42jDRAqdaLnP",
+            "INPUT_MINT": "So11111111111111111111111111111111111111112",
             "INPUT_AMOUNT": "0.2"
         }
     ]

--- a/scripts/create_pool/config.json
+++ b/scripts/create_pool/config.json
@@ -10,15 +10,15 @@
     ],
     "POOLS": [
         {
-            "TOKEN_MINT_A": "So11111111111111111111111111111111111111112",
-            "TOKEN_MINT_B": "H3ztN9SnJn3fZerXnN4TtdM9XkRpvCibdMKX9w3v4Ggf",
-            "TICK_SPACING": 32,
+            "TOKEN_MINT_A": "4yKRzD9MCGC39hb11kSfgnaA9sbKbBec42jDRAqdaLnP",
+            "TOKEN_MINT_B": "3JVvARFtkKwF6X8HQvt2GTTGsmaranqMk7YCn5RX7HG5",
+            "TICK_SPACING": 30,
             "OPEN_POSITION": true,
-            "INIT_AMOUNT_B_PER_A": "1.0",
+            "INIT_AMOUNT_B_PER_A": "3.0",
             "LOWER_B_PER_A_PRICE": "0.0001",
             "UPPER_B_PER_A_PRICE": "100",
             "SLIPPAGE": "1",
-            "INPUT_MINT": "So11111111111111111111111111111111111111112",
+            "INPUT_MINT": "4yKRzD9MCGC39hb11kSfgnaA9sbKbBec42jDRAqdaLnP",
             "INPUT_AMOUNT": "0.2"
         }
     ]

--- a/scripts/create_pool/utils/pool.ts
+++ b/scripts/create_pool/utils/pool.ts
@@ -10,9 +10,15 @@ export async function askToConfirmPoolInfo(poolInfo: PoolInfo): Promise<void> {
     output: process.stdout,
   });
 
+  let message = "";
+  if (poolInfo.isTokenReversed) {
+    message =
+      "\n---> WARNING: This pool token order is reversed, and the correct pool information is adjusted as the following.\n";
+  }
   await new Promise<void>((resolve) => {
     rl.question(
-      ` This is your pool information: 
+      ` ${message} \n
+        This is your pool information: 
           -----------------------------------------------
           token_a: ${poolInfo.tokenMintA}  
           token_b: ${poolInfo.tokenMintB} 
@@ -52,9 +58,6 @@ export function checkTokenReversed(
   }
 }
 
-/**
- * @note This fuction should be fix when use
- */
 export function getPoolInfo(poolIndex: number): PoolInfo {
   let pool = config.POOLS[poolIndex];
 
@@ -101,5 +104,6 @@ export function getPoolInfo(poolIndex: number): PoolInfo {
     slippage: new Decimal(pool.SLIPPAGE),
     inputMint: pool.INPUT_MINT,
     inputAmount: new Decimal(pool.INPUT_AMOUNT),
+    isOpenPosition: pool.OPEN_POSITION,
   };
 }

--- a/scripts/create_pool/utils/pool.ts
+++ b/scripts/create_pool/utils/pool.ts
@@ -76,8 +76,8 @@ export function getPoolInfo(poolIndex: number): PoolInfo {
 
   // Get default pool info
   let initialAmountBPerA = new Decimal(pool.INIT_AMOUNT_B_PER_A);
-  let lowerBPerAPrice = new Decimal(pool.INIT_AMOUNT_B_PER_A);
-  let upperBPerAPrice = new Decimal(pool.INIT_AMOUNT_B_PER_A);
+  let lowerBPerAPrice = new Decimal(pool.LOWER_B_PER_A_PRICE);
+  let upperBPerAPrice = new Decimal(pool.UPPER_B_PER_A_PRICE);
 
   let correctInitialAmountBPerA = initialAmountBPerA;
   let correctLowerBPerAPrice = lowerBPerAPrice;

--- a/scripts/create_pool/utils/pool.ts
+++ b/scripts/create_pool/utils/pool.ts
@@ -1,0 +1,105 @@
+import readline from "readline";
+import Decimal from "decimal.js";
+import config from "../config.json";
+import { PoolUtil } from "@renec/redex-sdk";
+import { PoolInfo } from "./types";
+
+export async function askToConfirmPoolInfo(poolInfo: PoolInfo): Promise<void> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  await new Promise<void>((resolve) => {
+    rl.question(
+      ` This is your pool information: 
+          -----------------------------------------------
+          token_a: ${poolInfo.tokenMintA}  
+          token_b: ${poolInfo.tokenMintB} 
+          tick_spacing: ${poolInfo.tickSpacing} 
+          price_b_per_a: ${poolInfo.initialAmountBPerA.toFixed(6)} 
+          lower_b_per_a_price: ${poolInfo.lowerBPerAPrice.toFixed(6)} 
+          upper_b_per_a_price: ${poolInfo.upperBPerAPrice.toFixed(6)} 
+          slippage: ${poolInfo.slippage.toFixed(6)} 
+          input_mint: ${poolInfo.inputMint} 
+          input_amount: ${poolInfo.inputAmount.toFixed(6)}
+          -----------------------------------------------
+          Do you want to proceed? (y/n) `,
+      (answer) => {
+        rl.close();
+        if (answer.toLowerCase() !== "y") {
+          console.log("Aborting ....");
+          process.exit(0);
+        }
+        resolve();
+      }
+    );
+  });
+}
+
+export function checkTokenReversed(
+  configTokenA: string,
+  configTokenB: string,
+  sortedTokenA: string,
+  sortedTokenB: string
+): boolean {
+  if (configTokenA === sortedTokenA && configTokenB === sortedTokenB) {
+    return false;
+  } else if (configTokenA === sortedTokenB && configTokenB === sortedTokenA) {
+    return true;
+  } else {
+    throw new Error("Token order is not matched");
+  }
+}
+
+/**
+ * @note This fuction should be fix when use
+ */
+export function getPoolInfo(poolIndex: number): PoolInfo {
+  let pool = config.POOLS[poolIndex];
+
+  const correctTokenOrder = PoolUtil.orderMints(
+    pool.TOKEN_MINT_A,
+    pool.TOKEN_MINT_B
+  );
+
+  let mintAPub = correctTokenOrder[0].toString();
+  let mintBPub = correctTokenOrder[1].toString();
+
+  // Check if pool is reversed
+  let isTokenReversed = checkTokenReversed(
+    pool.TOKEN_MINT_A,
+    pool.TOKEN_MINT_B,
+    mintAPub,
+    mintBPub
+  );
+
+  // Get default pool info
+  let initialAmountBPerA = new Decimal(pool.INIT_AMOUNT_B_PER_A);
+  let lowerBPerAPrice = new Decimal(pool.INIT_AMOUNT_B_PER_A);
+  let upperBPerAPrice = new Decimal(pool.INIT_AMOUNT_B_PER_A);
+
+  let correctInitialAmountBPerA = initialAmountBPerA;
+  let correctLowerBPerAPrice = lowerBPerAPrice;
+  let correctUpperBPerAPrice = upperBPerAPrice;
+
+  // Get correct pool info
+  if (isTokenReversed) {
+    correctInitialAmountBPerA = initialAmountBPerA.pow(-1);
+    correctLowerBPerAPrice = upperBPerAPrice.pow(-1);
+    correctUpperBPerAPrice = lowerBPerAPrice.pow(-1);
+  }
+
+  return {
+    isTokenReversed,
+    tokenMintA: mintAPub,
+    tokenMintB: mintBPub,
+    tickSpacing: pool.TICK_SPACING,
+    initialAmountBPerA: correctInitialAmountBPerA,
+    lowerBPerAPrice: correctLowerBPerAPrice,
+    upperBPerAPrice: correctUpperBPerAPrice,
+    slippage: new Decimal(pool.SLIPPAGE),
+    inputMint: pool.INPUT_MINT,
+    inputAmount: new Decimal(pool.INPUT_AMOUNT),
+  };
+}

--- a/scripts/create_pool/utils/types.ts
+++ b/scripts/create_pool/utils/types.ts
@@ -12,4 +12,5 @@ export type PoolInfo = {
   slippage: Decimal;
   inputMint: Address;
   inputAmount: Decimal;
+  isOpenPosition: boolean;
 };

--- a/scripts/create_pool/utils/types.ts
+++ b/scripts/create_pool/utils/types.ts
@@ -1,0 +1,15 @@
+import { Address } from "@project-serum/anchor";
+import Decimal from "decimal.js";
+
+export type PoolInfo = {
+  isTokenReversed: boolean; // this check with the config file
+  tokenMintA: Address;
+  tokenMintB: Address;
+  tickSpacing: number;
+  initialAmountBPerA: Decimal;
+  lowerBPerAPrice: Decimal;
+  upperBPerAPrice: Decimal;
+  slippage: Decimal;
+  inputMint: Address;
+  inputAmount: Decimal;
+};


### PR DESCRIPTION
## Vivify ticket

  *`[BDFR-393](https://app.vivifyscrum.com/boards/114704/sprint-backlog/373800/BDFR-393)`*

## PR Dependencies 
https://github.com/renec-chain/nemo-swap/pull/11
https://github.com/renec-chain/nemo-swap/pull/12

## Note
- Get correct pool info before performing init_pool, open_position, close_position
- Show a prompt to ask user to verify pool information before proceeding 

## Screenshots
<img width="624" alt="image" src="https://github.com/renec-chain/nemo-swap/assets/125954722/4905a3ff-aee5-4389-a51a-ba2c7cbc0ace">

![image](https://github.com/renec-chain/nemo-swap/assets/125954722/5a9a1206-12d9-44ce-bd36-7c49a8040756)

The pictures show a `config.json` file  with incorrect token order of a pool. Following Whirlpool requirements, the token need to be sorted in `canonical order`. 

## Reversing mechanism 
- if token order is not reversed, get the data and proceeded as normal
- if token is reversed, do the following 

```
 correctInitialAmountBPerA = 1 / initialAmountBPerA;
 correctLowerBPerAPrice = 1 / upperBPerAPrice;
 correctUpperBPerAPrice = 1 / lowerBPerAPrice;
```    
The detail of the scripts is in `scripts/create_pool/utils/pool.ts`

## Checklist
  <pre lang="checklist">
  https://checklist.remop.info/remitano-remitano/pr-nemoswap-13
  </pre>

